### PR TITLE
Remove Lint/MissingSuper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.0.8 2020-10-01
+
+### Removed
+- Lint/MissingSuper
+
 # v1.0.7 2020-09-29
 
 Updated Rubocop Version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_cop (1.0.7)
+    nxt_cop (1.0.8)
       rubocop (= 0.92.0)
 
 GEM

--- a/default.yml
+++ b/default.yml
@@ -58,7 +58,7 @@ Lint/IdentityComparison:
 Lint/Loop:
   Enabled: false
 Lint/MissingSuper:
-  Enabled: true
+  Enabled: false
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 Lint/OutOfRangeRegexpRef:

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '1.0.7'.freeze
+  VERSION = '1.0.8'.freeze
 end


### PR DESCRIPTION
I think this is the one Lint cop we can do without

https://docs.rubocop.org/rubocop/0.89/cops_lint.html#lintmissingsuper