### PR TITLE
Add rubocop-rails dep; use Rails/TimeZone cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,2 @@
 inherit_from: default.yml
+require: rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,26 @@ PATH
   specs:
     nxt_cop (1.0.9)
       rubocop (= 0.92.0)
+      rubocop-rails (~> 2.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.3.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.1)
+    concurrent-ruby (1.1.7)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.2)
     parallel (1.19.2)
     parser (2.7.2.0)
       ast (~> 2.4.1)
+    rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.1)
     regexp_parser (1.8.2)
@@ -24,10 +36,18 @@ GEM
       rubocop-ast (>= 0.5.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.8.0)
+    rubocop-ast (1.0.1)
       parser (>= 2.7.1.5)
+    rubocop-rails (2.8.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby

--- a/default.yml
+++ b/default.yml
@@ -100,3 +100,5 @@ Security:
 Style/Semicolon:
   Exclude:
     - spec/**/*
+Rails/TimeZone:
+  Enabled: true

--- a/nxt_cop.gemspec
+++ b/nxt_cop.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '0.92.0'
+  spec.add_dependency 'rubocop-rails', '~> 2.8'
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'
 end


### PR DESCRIPTION
# Background
Using `Time.parse` in specs can cause some specs to fail when running in different timezones. It was decided that it's safer to use `Time.zone.parse` instead since it uses the zone specified in the app config.
There is a cop in `rubocop-rails` already that checks this rule so it will be easier to stick with the `Time.zone` approach.