### PR TITLE
Enable Style/HashSyntax cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.0.10 2020-12-01
+
+### Added
+- `Style/HashSyntax`
+
 # v1.0.9 2020-10-15
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_cop (1.0.9)
+    nxt_cop (1.0.10)
       rubocop (= 0.92.0)
       rubocop-rails (~> 2.8)
 
@@ -19,7 +19,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     minitest (5.14.2)
-    parallel (1.19.2)
+    parallel (1.20.0)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     rack (2.2.3)
@@ -36,7 +36,7 @@ GEM
       rubocop-ast (>= 0.5.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.0.1)
+    rubocop-ast (1.1.1)
       parser (>= 2.7.1.5)
     rubocop-rails (2.8.1)
       activesupport (>= 4.2.0)
@@ -44,10 +44,10 @@ GEM
       rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.7)
+    tzinfo (1.2.8)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.1)
 
 PLATFORMS
   ruby

--- a/default.yml
+++ b/default.yml
@@ -95,6 +95,8 @@ Style/TrailingCommaInArguments:
   Enabled: true
 Style/WordArray:
   Enabled: true
+Style/HashSyntax:
+  Enabled: true
 Security:
   Enabled: true
 Style/Semicolon:

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '1.0.9'.freeze
+  VERSION = '1.0.10'.freeze
 end


### PR DESCRIPTION
As discussed yesterday, there are places where the new (Ruby 1.9+) hash syntax is not being used yet, although it comes by default in plain rubocop configurations.
Let's stick to the new (well not so new anymore) hash syntax!

More details on this cop:
https://rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax

## TODO
- [x] get reviewed
- [x] get merged
- [ ] get released