### PR TITLE
Change allowed host

### DIFF
--- a/nxt_cop.gemspec
+++ b/nxt_cop.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+    spec.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/nxt-insurance'
 
     spec.metadata['homepage_uri'] = spec.homepage
     spec.metadata['source_code_uri'] = 'https://github.com/nxt-insurance/nxt_cop'


### PR DESCRIPTION
This was originally change by @nsommer  in https://github.com/nxt-insurance/nxt_cop/commit/429b206d9ea00840b6b7e1939f485ea067099b3f

It prevented me from releasing the gem with the following error
```
ERROR:  "https://rubygems.pkg.github.com/nxt-insurance" is not allowed by the gemspec, which only allows "https://rubygems.org"
```

I was only able to release the gem after reverting the changes.