### PR TITLE
Allow including repos use their own ruby version

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -11,7 +11,6 @@ AllCops:
     - db/migrate/*
     - vendor/**/*
     - node_modules/**/*
-  TargetRubyVersion: 2.6
   DisabledByDefault: true
 Layout/DotPosition:
   EnforcedStyle: trailing
@@ -100,6 +99,7 @@ Style/WordArray:
   Enabled: true
 Style/HashSyntax:
   Enabled: true
+  EnforcedShorthandSyntax: either
 Security:
   Enabled: true
 Style/Semicolon:


### PR DESCRIPTION
Hardcoding the `TargetRubyVersion` to 2.6 means that even if the project's `ruby-version` is on a higher version, we can't use any 2.7+ features 😕. This PR fixes that.

(The `EnforcedShorthandSyntax: either` stops RuboCop from erroring if you don't use the Ruby 3.1 has shorthand.)