### PR TITLE
Disable Layout/MultilineMethodCallIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-# v1.0.15 2022-05-18
-
+# v1.0.16 2022-06-24
 ## What's Changed
 * Disable Layout/MultilineMethodCallIndentation ([#30](https://github.com/nxt-insurance/nxt_cop/pull/34))
 
@@ -7,6 +6,12 @@
 
 
 # v1.0.15 2022-05-18
+
+## What's Changed
+* Don't enforce trailing comma in hash literals rule ([#30](https://github.com/nxt-insurance/nxt_cop/pull/30))
+
+**Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.14...v1.0.15
+
 # v1.0.14 2022-05-04
 
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # v1.0.15 2022-05-18
 
 ## What's Changed
-* Don't enforce trailing comma in hash literals rule ([#30](https://github.com/nxt-insurance/nxt_cop/pull/30))
+* Disable Layout/MultilineMethodCallIndentation ([#30](https://github.com/nxt-insurance/nxt_cop/pull/34))
 
-**Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.14...v1.0.15
+**Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.15...v1.0.16
 
+
+# v1.0.15 2022-05-18
 # v1.0.14 2022-05-04
 
 ## What's Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    nxt_cop (1.0.15)
+    nxt_cop (1.0.16)
       rubocop (= 1.28.2)
       rubocop-rails (~> 2.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.4)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -17,14 +17,14 @@ GEM
     concurrent-ruby (1.1.10)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.15.0)
+    minitest (5.16.1)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.3.1)
+    regexp_parser (2.5.0)
     rexml (3.2.5)
     rubocop (1.28.2)
       parallel (~> 1.10)
@@ -35,9 +35,9 @@ GEM
       rubocop-ast (>= 1.17.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.17.0)
+    rubocop-ast (1.18.0)
       parser (>= 3.1.1.0)
-    rubocop-rails (2.14.2)
+    rubocop-rails (2.15.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)

--- a/default.yml
+++ b/default.yml
@@ -21,7 +21,7 @@ Layout/IndentationConsistency:
 Layout/IndentationStyle:
   Enabled: true
 Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented_relative_to_receiver
+  Enabled: false
 Layout/SpaceBeforeBlockBraces:
   Enabled: true
 Layout/SpaceInsideBlockBraces:

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '1.0.15'.freeze
+  VERSION = '1.0.16'.freeze
 end


### PR DESCRIPTION
This stops RuboCop from rejecting

```ruby
insurance_change_requests = InsuranceManagement::Executor.do_thing.
   next_thing.
   other_thing
```

and insisting on

```ruby
insurance_change_requests = InsuranceManagement::Executor.do_thing.  
                              next_thing.
                              other_thing
```

which results in a lot of inconvenient vertical scrolling back and forth :confused:.