### PR TITLE
Configure recently-added cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.0.16 2022-07-07
+
+## What's Changed
+* Add RSpec/Focus cop ([#38](https://github.com/nxt-insurance/nxt_cop/pull/38))
+* Configure recently added cops ([#39](https://github.com/nxt-insurance/nxt_cop/pull/39))
+
+**Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.15...v1.0.16
+
 # v1.0.15 2022-05-18
 
 ## What's Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     nxt_cop (1.0.16)
-      rubocop (= 1.31.1)
+      rubocop (~> 1.31.2)
       rubocop-rails (~> 2.8)
       rubocop-rspec (~> 2.12)
 
@@ -28,7 +28,7 @@ GEM
     rake (13.0.6)
     regexp_parser (2.5.0)
     rexml (3.2.5)
-    rubocop (1.31.1)
+    rubocop (1.31.2)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_cop (1.0.15)
+    nxt_cop (1.0.16)
       rubocop (= 1.31.1)
       rubocop-rails (~> 2.8)
       rubocop-rspec (~> 2.12)

--- a/default.yml
+++ b/default.yml
@@ -131,6 +131,10 @@ Lint/SymbolConversion:
   Enabled: true
 Lint/UnmodifiedReduceAccumulator:
   Enabled: true
+Lint/OrAssignmentToConstant:
+  Enabled: true
+Lint/RedundantDirGlobSort:
+  Enabled: true
 
 # These checks are valid, but better left to programmer's discretion, as the effects are harmless.
 Lint/DuplicateBranch:
@@ -155,12 +159,8 @@ Lint/NoReturnInBeginEndBlocks:
   Enabled: false
 Lint/NumberedParameterAssignment:
   Enabled: false
-Lint/OrAssignmentToConstant:
-  Enabled: true
-Lint/RedundantDirGlobSort:
-  Enabled: true
 Lint/RefinementImportMethods:
-  Enabled: true
+  Enabled: false
 Lint/RequireRelativeSelfPath:
   Enabled: false
 Lint/ToEnumArguments:

--- a/default.yml
+++ b/default.yml
@@ -103,7 +103,7 @@ Style/HashSyntax:
   Enabled: true
   EnforcedShorthandSyntax: either
 Security:
-  Enabled: true
+  EnabledByDefault: true
 Style/Semicolon:
   Exclude:
     - spec/**/*
@@ -113,3 +113,58 @@ RSpec:
   Enabled: false
 RSpec/Focus:
   Enabled: true
+Lint/AmbiguousAssignment:
+  Enabled: true
+Lint/DeprecatedConstants:
+  Enabled: true
+Lint/AmbiguousRange:
+  Enabled: true
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: true
+Lint/TripleQuotes:
+  Enabled: true
+Lint/ConstantOverwrittenInRescue:
+  Enabled: true
+Lint/NonAtomicFileOperation:
+  Enabled: true
+Lint/SymbolConversion:
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
+
+# These checks are valid, but better left to programmer's discretion, as the effects are harmless.
+Lint/DuplicateBranch:
+  Enabled: false
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: false
+Lint/EmptyBlock:
+  Enabled: false
+Lint/EmptyClass:
+  Enabled: false
+Lint/EmptyInPattern:
+  Enabled: false
+Lint/UnexpectedBlockArity:
+  Enabled: false
+
+# These code patterns are rare/nonexistent in our code, so checking for them is a waste of time
+Lint/IncompatibleIoSelectWithFiberScheduler:
+  Enabled: false
+Lint/LambdaWithoutLiteralBlock:
+  Enabled: false
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: false
+Lint/NumberedParameterAssignment:
+  Enabled: false
+Lint/OrAssignmentToConstant:
+  Enabled: true
+Lint/RedundantDirGlobSort:
+  Enabled: true
+Lint/RefinementImportMethods:
+  Enabled: true
+Lint/RequireRelativeSelfPath:
+  Enabled: false
+Lint/ToEnumArguments:
+  Enabled: false
+Lint/UselessRuby2Keywords:
+  Enabled: false
+

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '1.0.15'.freeze
+  VERSION = '1.0.16'.freeze
 end

--- a/nxt_cop.gemspec
+++ b/nxt_cop.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '1.31.2'
+  spec.add_dependency 'rubocop', '~> 1.31.2'
   spec.add_dependency 'rubocop-rails', '~> 2.8'
   spec.add_dependency 'rubocop-rspec', '~> 2.12'
   spec.add_development_dependency 'bundler', '~> 2.1'


### PR DESCRIPTION
This PR enables/disables the recently added default cops, so RuboCop can stop bugging us about them (and of course, some are quite useful).

I've tried to use sensible defaults by enabling rules that might be useful, and disabling those that are low-reward. There might be a few issues to fix in the projects, but they should be minor, auto-correctable things.