### PR TITLE
Adjust enforcement style of Lint/SymbolConversion rule; update Rubocop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v1.0.17 2022-08-19
 
 ## What's Changed
-* Disable the recently added  Lint/SymbolConversion cop ([#45](https://github.com/nxt-insurance/nxt_cop/pull/45))
+* Adjust severity of the recently added  Lint/SymbolConversion cop ([#45](https://github.com/nxt-insurance/nxt_cop/pull/45))
 
 **Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.15...v1.0.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.0.17 2022-08-19
+
+## What's Changed
+* Disable the recently added  Lint/SymbolConversion cop ([#45](https://github.com/nxt-insurance/nxt_cop/pull/45))
+
+**Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.15...v1.0.16
+
 # v1.0.16 2022-07-07
 
 ## What's Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_cop (1.0.16)
+    nxt_cop (1.0.17)
       rubocop (~> 1.35.0)
       rubocop-rails (~> 2.8)
       rubocop-rspec (~> 2.12)
@@ -9,17 +9,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
     concurrent-ruby (1.1.10)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
-    minitest (5.16.2)
+    minitest (5.16.3)
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
@@ -47,7 +47,7 @@ GEM
     rubocop-rspec (2.12.1)
       rubocop (~> 1.31)
     ruby-progressbar (1.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Release a new version
 
+```shell
+bundle config set gem.push_key rubygems
+```
+
+Add to `~/.gem/credentials` (create if it doesn't exist):
+
+```shell
+:rubygems: <your Rubygems API key>
+```
+
 To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing

--- a/default.yml
+++ b/default.yml
@@ -77,6 +77,8 @@ Lint/SelfAssignment:
   Enabled: true
 Lint/StructNewOverride:
   Enabled: true
+Lint/SymbolConversion:
+  Enabled: false
 Lint/TopLevelReturnWithArgument:
   Enabled: true
 Lint/TrailingCommaInAttributeDeclaration:
@@ -127,16 +129,16 @@ Lint/ConstantOverwrittenInRescue:
   Enabled: true
 Lint/NonAtomicFileOperation:
   Enabled: true
-Lint/SymbolConversion:
-  Enabled: true
 Lint/UnmodifiedReduceAccumulator:
   Enabled: true
 Lint/OrAssignmentToConstant:
   Enabled: true
 Lint/RedundantDirGlobSort:
   Enabled: true
+Lint/RequireRangeParentheses:
+  Enabled: true
 
-# These checks are valid, but better left to programmer's discretion, as the effects are harmless.
+# These checks are valid, but better left to programmer's discretion, as the effects of such code are harmless.
 Lint/DuplicateBranch:
   Enabled: false
 Lint/DuplicateRegexpCharacterClassElement:

--- a/default.yml
+++ b/default.yml
@@ -78,7 +78,7 @@ Lint/SelfAssignment:
 Lint/StructNewOverride:
   Enabled: true
 Lint/SymbolConversion:
-  Enabled: false
+  EnforcedStyle: consistent
 Lint/TopLevelReturnWithArgument:
   Enabled: true
 Lint/TrailingCommaInAttributeDeclaration:

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '1.0.16'.freeze
+  VERSION = '1.0.17'.freeze
 end


### PR DESCRIPTION
In https://github.com/nxt-insurance/nxt_cop/pull/39, one of the newly enabled cops was `Lint/SymbolConversion`, which disallows code like `{"key": "value"}` in favour of `{key: "value"}`. It's not a bad rule, but it can be a bit cumbersome (sometimes, some content is copied from JSON, and removing the quotes each time is stressful). And there are over 200 offences in Insurance Service, I think it's harmless, so we can disable it.