### PR TITLE
Enable Rails/Date cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
+# v1.0.18
+
+## What's Changed
+* Add `Rails/Date` cop ([#50](https://github.com/nxt-insurance/nxt_cop/pull/50))
+
+**Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.17...v1.0.18
+
 # v1.0.17 2022-08-19
 
 ## What's Changed
 * Adjust severity of the recently added  Lint/SymbolConversion cop ([#45](https://github.com/nxt-insurance/nxt_cop/pull/45))
 
-**Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.15...v1.0.16
+**Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.16...v1.0.17
 
 # v1.0.16 2022-07-07
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_cop (1.0.17)
+    nxt_cop (1.0.18)
       rubocop (~> 1.35.0)
       rubocop-rails (~> 2.8)
       rubocop-rspec (~> 2.12)
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3.1)
+    activesupport (7.0.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -23,12 +23,12 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    rack (2.2.4)
+    rack (3.0.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.5.0)
+    regexp_parser (2.6.0)
     rexml (3.2.5)
-    rubocop (1.35.0)
+    rubocop (1.35.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)
@@ -40,16 +40,16 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
-    rubocop-rails (2.15.2)
+    rubocop-rails (2.16.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 1.7.0, < 2.0)
-    rubocop-rspec (2.12.1)
-      rubocop (~> 1.31)
+      rubocop (>= 1.33.0, < 2.0)
+    rubocop-rspec (2.13.2)
+      rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.3.0)
 
 PLATFORMS
   ruby

--- a/default.yml
+++ b/default.yml
@@ -111,6 +111,8 @@ Style/Semicolon:
     - spec/**/*
 Rails/TimeZone:
   Enabled: true
+Rails/Date:
+  Enabled: true
 RSpec:
   Enabled: false
 RSpec/Focus:

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '1.0.17'.freeze
+  VERSION = '1.0.18'.freeze
 end


### PR DESCRIPTION
Following on from @AkihikoITOH 's suggestion and the discussion in Slack, enables [`Rails/Date`](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsdate).

Full explanation: https://thoughtbot.com/blog/its-about-time-zones

Summary:

> DON’T USE
> * `Time.now`
> * `Date.today`
> * `Date.today.to_time`
> * `Time.parse("2015-07-04 17:05:37")`
> * `Time.strptime(string, "%Y-%m-%dT%H:%M:%S%z")`
> DO USE
> * `Time.current`
> * `2.hours.ago`
> * `Time.zone.today`
> * `Date.current`
> * `1.day.from_now`
> * `Time.zone.parse("2015-07-04 17:05:37")`
> * `Time.strptime(string, "%Y-%m-%dT%H:%M:%S%z").in_time_zone`


## Practical experimen: `Date.today` vs `Time.zone.today`
`Date.today` will always return the system time, while `Time.zone.today` will respect the app's time zone.

1. Set your system timezone to UTC (Accra, Ghana is perfect for this).
<img width="585" alt="image" src="https://user-images.githubusercontent.com/104110245/193029889-873a43c9-db9a-4649-8068-fd9fb1423c40.png">

2. Set your system time to 23:xx. This will (as of now) be 01:xx on the next day in Berlin.
<img width="572" alt="image" src="https://user-images.githubusercontent.com/104110245/193029937-32d712c9-9ce6-41a3-945b-b795625dd0fc.png">

3. Open your Rails app. Note that the time zone is set to Berlin (`config.time_zone = 'Berlin'` in `config/application.rb`).
4. Run `Date.today` and `Time.zone.today` in the Rails console (`bin/rails c`). Result:

<img width="449" alt="image" src="https://user-images.githubusercontent.com/104110245/193030330-74fec480-f0e7-4e60-a8f0-813692b10465.png">

We're susceptible to this because our servers are likely in UTC (Heroku, CircleCI) but our application time zone is Berlin. It's one reason for flaky tests, and it may also lead to other slight bugs, especially for things that run around midnight.