### PR TITLE
BE-20 Leading dot for method invocation, layout cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.1.0 2023-05-05
+## What's Changed
+* Change `DotPosition` to enforce leading dots for method invocation
+* Add multiple autocorrectable layout cops
+
+**Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.19...v1.1.0
 # v1.0.19 2023-04-04
 
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add multiple autocorrectable layout cops
 
 **Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.19...v1.1.0
+
 # v1.0.19 2023-04-04
 
 ## What's Changed

--- a/default.yml
+++ b/default.yml
@@ -242,3 +242,7 @@ Lint/ToEnumArguments:
   Enabled: false
 Lint/UselessRuby2Keywords:
   Enabled: false
+Lint/DuplicateMagicComment:
+  Enabled: false
+Lint/UselessRescue:
+  Enabled: false

--- a/default.yml
+++ b/default.yml
@@ -244,4 +244,3 @@ Lint/ToEnumArguments:
   Enabled: false
 Lint/UselessRuby2Keywords:
   Enabled: false
-  

--- a/default.yml
+++ b/default.yml
@@ -244,3 +244,7 @@ Lint/DuplicateMagicComment:
   Enabled: false
 Lint/UselessRescue:
   Enabled: false
+Lint/DuplicateMagicComment:
+  Enabled: false
+Lint/UselessRescue:
+  Enabled: false

--- a/default.yml
+++ b/default.yml
@@ -3,7 +3,6 @@ require:
 - rubocop-rspec
 AllCops:
   Exclude:
-    # generated files
     - bin/guard
     - bin/rspec
     - bin/rubocop
@@ -15,16 +14,82 @@ AllCops:
     - node_modules/**/*
   DisabledByDefault: true
 
+# A bunch of these layout cops are enabled by default,
+# but for some reason 'DisableByDefault' is set to 'true' above.
+# Removing this configuration leads to a lot of violations triggered
+# by other cops that are not auto-correctable.
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+Layout/ArrayAlignment:
+  EnforcedStyle: with_fixed_indentation
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: key
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+Layout/MultilineArrayLineBreaks:
+  Enabled: true
+Layout/MultilineAssignmentLayout:
+  EnforcedStyle: new_line
+Layout/MultilineBlockLayout:
+  Enabled: true
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+Layout/MultilineHashBraceLayout:
+  Enabled: true
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: true
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+Layout/MultilineMethodCallBraceLayout:
+  EnforcedStyle: new_line
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+Layout/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: new_line
+Layout/SpaceAroundOperators:
+  AllowForAlignment: false
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+Layout/FirstMethodParameterLineBreak:
+  Enabled: true
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: start_of_line
+Layout/BlockAlignment:
+  EnforcedStyleAlignWith: start_of_block
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
+Layout/IndentationWidth:
+  Enabled: true
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+Layout/FirstArgumentIndentation:
+  Enabled: true
+Layout/ElseAlignment:
+  Enabled: true
+Layout/FirstHashElementIndentation:
+  Enabled: true
+Layout/AssignmentIndentation:
+  Enabled: true
+Layout/CaseIndentation:
+  Enabled: true
+Layout/MultilineArrayBraceLayout:
+  Enabled: true
+Layout/BeginEndAlignment:
+  Enabled: true
+Layout/CommentIndentation:
+  Enabled: true
 Layout/DotPosition:
-  EnforcedStyle: trailing
+  EnforcedStyle: leading
 Layout/EmptyLineAfterGuardClause:
   Enabled: true
 Layout/IndentationConsistency:
   Enabled: true
-Layout/IndentationStyle:
+Layout/MultilineMethodParameterLineBreaks:
   Enabled: true
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented_relative_to_receiver
 Layout/SpaceBeforeBlockBraces:
   Enabled: true
 Layout/SpaceInsideBlockBraces:
@@ -179,4 +244,4 @@ Lint/ToEnumArguments:
   Enabled: false
 Lint/UselessRuby2Keywords:
   Enabled: false
-
+  

--- a/default.yml
+++ b/default.yml
@@ -34,8 +34,6 @@ Layout/MultilineHashKeyLineBreaks:
   Enabled: true
 Layout/MultilineHashBraceLayout:
   Enabled: true
-Layout/MultilineMethodArgumentLineBreaks:
-  Enabled: true
 Layout/FirstMethodArgumentLineBreak:
   Enabled: true
 Layout/MultilineMethodCallBraceLayout:

--- a/default.yml
+++ b/default.yml
@@ -28,8 +28,6 @@ Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 Layout/MultilineArrayLineBreaks:
   Enabled: true
-Layout/MultilineAssignmentLayout:
-  EnforcedStyle: new_line
 Layout/MultilineBlockLayout:
   Enabled: true
 Layout/MultilineHashKeyLineBreaks:

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '1.0.19'.freeze
+  VERSION = '1.1.0'.freeze
 end


### PR DESCRIPTION
[Ticket](https://hellogetsafe.atlassian.net/browse/BE-20)

This PR changes the `DotPosition` cop to enforce leading dots when calling methods.
It also introduces a bunch of auto-correctable layout cops in order to achieve consistency of indentation across our projects.