### PR TITLE
Add inherit_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.3.0 2023-09-22
+## What's Changed
+* `inherit_mode` was added to `default.yml`
+
+**Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.2.1...v1.3.0
+
 # v1.2.1 2023-08-23
 ## What's Changed
 * Add `Lint/MixedCaseRange`

--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,12 @@
 require:
 - rubocop-rails
 - rubocop-rspec
+
+inherit_mode:
+  merge:
+    - Exclude
+    - Include
+
 AllCops:
   Exclude:
     - bin/guard

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.3.0'.freeze
 end


### PR DESCRIPTION
This PR adds `inherit_mode` to `default.yml`.

Without it, any custom modifications to `.rubocop.yml` files in repos which inherit from `nxt_cop` will cause crashes, since apparently `rubocop` will try to pick up configs of installed dependencies.

I haven't looked deeply into the actual problem yet, but `inherit_mode` helped in `.rubocop.yml` [here](https://github.com/nxt-insurance/user-service/pull/3204#discussion_r1334279298), and it also solves the issue when extracted to `nxt_cop` ([4d773a5](https://github.com/nxt-insurance/user-service/pull/3204/commits/4d773a58641b1803172218b0a8c85d9ad5b3a6b0)).