### PR TITLE
Disable more cops before rolling out 2.0.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.0.1 2024-01-10
+## What's Changed
+* Disable more cops depending on the code style in our backend-services
+
+* **Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v2.0.0...v2.0.1
+
 # v2.0.0 2023-11-28
 ## What's Changed
 * Enabled all cops by default

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_cop (2.0.0)
+    nxt_cop (2.0.1)
       rubocop (~> 1.60.0)
       rubocop-rails (~> 2.8)
       rubocop-rspec (~> 2.12)
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.2)
+    activesupport (7.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -22,7 +22,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.5)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     drb (2.2.0)
       ruby2_keywords
@@ -30,10 +30,10 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    minitest (5.20.0)
+    minitest (5.21.1)
     mutex_m (0.2.0)
     parallel (1.24.0)
-    parser (3.3.0.2)
+    parser (3.3.0.4)
       ast (~> 2.4.1)
       racc
     racc (1.7.3)

--- a/default.yml
+++ b/default.yml
@@ -429,6 +429,34 @@ Style/RedundantInterpolation:
   Enabled: false
 Style/ZeroLengthPredicate:
   Enabled: false
+Style/MultilineTernaryOperator:
+  Enabled: false
+Style/RedundantReturn:
+  Enabled: false
+Style/ClassCheck:
+  Enabled: false
+Style/LineEndConcatenation:
+  Enabled: false
+Style/RedundantFetchBlock:
+  Enabled: false
+Style/FloatDivision:
+  Enabled: false
+Layout/MultilineOperationIndentation:
+  Enabled: false
+Style/SoleNestedConditional:
+  Enabled: false
+Rails/FindEach:
+  Enabled: false
+Style/RedundantParentheses:
+  Enabled: false
+Style/IfInsideElse:
+  Enabled: false
+Style/EmptyCaseCondition:
+  Enabled: false
+Style/TernaryParentheses:
+  EnforcedStyle: require_parentheses_when_complex
+Style/HashLikeCase:
+  Enabled: false
 
 # 🤔 Should we enable these cops or not? They look useful but require alignment within the team
 Style/OpenStructUse:

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end


### PR DESCRIPTION
### References
[help]: # (Add link/s to every reference related to this pull request: issue, migrations, another PRs, ...)
* **Issue:**  https://hellogetsafe.atlassian.net/browse/HAPPY-924
* **Related pull-requests:**
* **Sentry errors:**

### What is the goal? How is it being implemented?
[help]: # (Provide a description of the overall goal and a description of the implementation.)
After running `nxt_cop 2.0.0` against our backend services, I've found bunch of rules that we should keep disabled. Before rolling out new major version, let's disable them in shared config