### PR TITLE
Add rubocop-rspec_rails to `default.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.5.1 2024-06-12
+## What's Changed
+- Adds rubocop-rspec_rails to `.default.yml` to restore previous functionality
+
 # v2.5.0 2024-06-11
 ## What's Changed
 - Relaxes the rubocop version to not pin the patch

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_cop (2.5.0)
+    nxt_cop (2.5.1)
       rubocop (~> 1.60)
       rubocop-capybara (~> 2.21)
       rubocop-factory_bot (~> 2.26)

--- a/default.yml
+++ b/default.yml
@@ -2,6 +2,7 @@ require:
 - rubocop-factory_bot
 - rubocop-rails
 - rubocop-rspec
+- rubocop-rspec_rails
 - ./custom_cops/nxt_core/rails/use_of_rails_logger.rb
 
 inherit_mode:

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.5.1'.freeze
 end


### PR DESCRIPTION
Since rubocop-rspec split into 3 libraries, this now gives a warning on rails services.