### PR TITLE
Enables Naming/MemoizedInstanceVariableName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.6.0
+## What's Changed
+- Enables `Naming/MemoizedInstanceVariableName` cop (autocorrection: Always (Unsafe))
+
 # v2.5.1 2024-06-12
 ## What's Changed
 - Adds rubocop-rspec_rails to `.default.yml` to restore previous functionality
@@ -87,7 +91,7 @@ Bumped dependencies version
 ## What's Changed
 * Add `Layout/SpaceBeforeComma`
 * Add `Layout/SpaceAfterComma`
-* Add `Layout/EmptyLines` cops ([#80](https://github.com/nxt-insurance/nxt_cop/pull/80)) 
+* Add `Layout/EmptyLines` cops ([#80](https://github.com/nxt-insurance/nxt_cop/pull/80))
 
 **Full Changelog**: https://github.com/nxt-insurance/nxt_cop/compare/v1.0.18...v1.0.19
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_cop (2.5.1)
+    nxt_cop (2.6.0)
       rubocop (~> 1.60)
       rubocop-capybara (~> 2.21)
       rubocop-factory_bot (~> 2.26)

--- a/default.yml
+++ b/default.yml
@@ -116,6 +116,8 @@ Lint/RedundantDirGlobSort:
   Enabled: true
 Lint/RequireRangeParentheses:
   Enabled: true
+Naming/MemoizedInstanceVariableName:
+  Enabled: true
 
 # These checks are valid, but better left to programmer's discretion, as the effects of such code are harmless.
 Lint/DuplicateBranch:
@@ -367,8 +369,6 @@ Style/HashLikeCase:
 Style/OpenStructUse:
   Enabled: false
 Style/RedundantConstantBase: # new in 1.40
-  Enabled: false
-Naming/MemoizedInstanceVariableName:
   Enabled: false
 Style/ConditionalAssignment:
   Enabled: false

--- a/lib/nxt_cop/version.rb
+++ b/lib/nxt_cop/version.rb
@@ -1,3 +1,3 @@
 module NxtCop
-  VERSION = '2.5.1'.freeze
+  VERSION = '2.6.0'.freeze
 end


### PR DESCRIPTION
Enables [Naming/MemoizedInstanceVariableName](https://docs.rubocop.org/rubocop/cops_naming.html#namingmemoizedinstancevariablename). 

NOTE: This is not safe and most likely needs manual fixing.

> Safety
This cop relies on the pattern @instance_var ||= …​, but this is sometimes used for other purposes than memoization so this cop is considered unsafe. Also, its autocorrection is unsafe because it may conflict with instance variable names already in use.

```ruby
# bad
# Method foo is memoized using an instance variable that is
# not `@foo`. This can cause confusion and bugs.
def foo
  @something ||= calculate_expensive_thing
end

# good
def foo
  @foo ||= calculate_expensive_thing
end

```